### PR TITLE
Treat the environment variable LICE_USER as the default value for the default value of the user's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Options:
   -n, --name      The name of the generated license, [default `LICENSE`]
   -p, --path      License generation file path, [default `current working dir`]
   -s, --show      Show the contents of a license
-  -u, --user      The name to use in the generated license
+  -u, --user      The name to use in the generated license [default `$LICE_USER`]
   -v, --version   Display the version
   -y, --year      Year placeholder [default `current year`]
 

--- a/data/help.txt
+++ b/data/help.txt
@@ -8,7 +8,7 @@ Options:
   -n, --name     The name of the generated license, [default `LICENSE`]
   -p, --path     License generation file path, [default `current working dir`]
   -s, --show     Show the contents of a license
-  -u, --user     The name to use in the generated license
+  -u, --user     The name to use in the generated license [default `$LICE_USER`]
   -v, --version  Display the version
   -y, --year     Year placeholder [default `current year`]
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var args = require('minimist')(process.argv.slice(2), {
     filename: 'LICENSE',
     noprompt: true,
     path: process.cwd(),
+    user: process.env.LICE_USER,
     year: new Date().getFullYear()
   },
   boolean: [

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -18,15 +18,15 @@ function generate(opts) {
     var contents = fs.readFileSync(source, 'utf8');
     var license = licenses[opts.license];
 
-    if (license.placeholders.description) {
+    if (license.placeholders.description && opts.description) {
       var descriptionRegExp = new RegExp(license.placeholders.description);
       contents = contents.replace(descriptionRegExp, opts.description);
     }
-    if (license.placeholders.year) {
+    if (license.placeholders.year && opts.year) {
       var yearRegExp = new RegExp(license.placeholders.year);
       contents = contents.replace(yearRegExp, opts.year);
     }
-    if (license.placeholders.user) {
+    if (license.placeholders.user && opts.user) {
       var userRegExp = new RegExp(license.placeholders.user);
       contents = contents.replace(userRegExp, opts.user);
     }

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -58,6 +58,7 @@ function user(placeholder, cb) {
     type: 'input',
     name: 'user',
     message: 'Replace `' + placeholder.replace(/\\/g, '') + '` with:',
+    default: process.env.LICE_USER
   }, function(response) {
     cb(response.user);
   });


### PR DESCRIPTION
Having to type your name every time you want to make a new license gets a little annoying, so I decided to make a default settable as an environment variable. If the environment variable is not set, all the places where I added `process.env.LICE_USER` appears to also accept `undefined` as "no default," so nothing should be broken.

While I was testing this, I noticed that running `lice -g` before these changes would create a license where the name area was just replaced with "undefined." Since this is still what happens if `$LICE_USER` isn't set, I also tweaked the replacement code so that it wouldn't perform the replacement if the replacement text is falsy.