### PR TITLE
Allow uppercase license names to be passed via CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ var args = require('minimist')(process.argv.slice(2), {
   ]
 });
 
+if (args.license)
+  args.license = args.license.toLowerCase();
+
 if (args.help)
   return actions.help();
 


### PR DESCRIPTION
This PR allows upper and mixed case license names to be passed via the CLI (e.g., `lice -l MIT`).